### PR TITLE
fix issue11

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -164,6 +164,10 @@ func (b *block) defineSlot(t Type, temp bool) *Variable {
 	return v
 }
 
+func (b *block) UndefineConst(name string) () {
+    delete(b.defs, name)
+}
+
 func (b *block) DefineConst(name string, pos token.Pos, t Type, v Value) (*Constant, Def) {
 	if prev, ok := b.defs[name]; ok {
 		return nil, prev

--- a/stmt.go
+++ b/stmt.go
@@ -432,6 +432,8 @@ func (a *stmtCompiler) compileDecl(decl ast.Decl) {
 		}
 		fn := a.compileFunc(a.block, decl, d.Body)
 		if c == nil || fn == nil {
+            //when compile error, remove func identifier in the table
+            a.block.UndefineConst(d.Name.Name)
 			return
 		}
 		var zeroThread Thread


### PR DESCRIPTION
A try to fix issue #11 
Add undefineConst function in scope.go
When compileFunc in stmt.go return nil, indicating that func has error
undefine the identifier previously being defined

// I'm not sure this is the best way to deal with this, since undefined function is rare to use. To define it seems a stupid action.
